### PR TITLE
Changed to use dependencies in vendor_r directory

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -4,4 +4,3 @@
 .Rhistory
 .RData
 .Rhistory
-vendor_r

--- a/r.yml
+++ b/r.yml
@@ -1,8 +1,6 @@
 ---
 packages:
-- cran_mirror: https://raw.githubusercontent.com/USEPA/cflinuxfs3-CRAN/master/cflinuxfs3/
-  num_threads: 2
-  packages:
+- packages:
     - name: shinyjs
     - name: purrr
     - name: RJSONIO
@@ -12,4 +10,3 @@ packages:
     - name: shinyBS
     - name: kableExtra
     - name: knitr
-    - name: magrittr


### PR DESCRIPTION
Needed to update r.yml to delete the cran_mirror and remove vendor_r from .cfignore